### PR TITLE
Include pauses for the API.

### DIFF
--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -38,6 +38,11 @@ enum SideChoice {
   SideChoice_KnifeRound,  // There will be a knife round to choose sides
 };
 
+enum PauseType {
+  PauseType_Tech,      // Technical pause
+  PauseType_Tactical,  // Tactical Pause
+};
+
 // Called each get5-event with JSON formatted event text.
 forward void Get5_OnEvent(const char[] eventJson);
 
@@ -81,6 +86,12 @@ forward void Get5_OnSidePicked(MatchTeam team, const char[] map, int side);
 
 // Called when a demo finishes recording.
 forward void Get5_OnDemoFinished(const char[] filename);
+
+// Called when a match is paused.
+forward void Get5_OnMatchPaused(MatchTeam team, PauseType pauseReason);
+
+// Called when a match is unpaused.
+forward void Get5_OnMatchUnpaused(MatchTeam team);
 
 // Called when a match backup is restored.
 forward void Get5_OnBackupRestore();
@@ -135,6 +146,9 @@ native void Get5_GetMatchID(char[] id, int length);
 
 // Sets the current matchid.
 native void Get5_SetMatchID(const char[] id);
+
+// Returns the server ID as defined by get5_server_id.
+native int Get5_GetServerID();
 
 // Adds a cvar to be set when going live. If the cvar is already in the cvars for the match, the new
 // value will replace the old value if the override parameter is true.
@@ -202,7 +216,8 @@ native int Get5_IncreasePlayerStat(int client, const char[] statName, int amount
 #define STAT_MVP "mvp"
 
 public SharedPlugin __pl_get5 = {
-    name = "get5", file = "get5.smx",
+    name = "get5",
+    file = "get5.smx",
 #if defined REQUIRE_PLUGIN
     required = 1,
 #else
@@ -227,6 +242,7 @@ public __pl_get5_SetNTVOptional() {
   MarkNativeAsOptional("Get5_GetTeamScores");
   MarkNativeAsOptional("Get5_GetMatchID");
   MarkNativeAsOptional("Get5_SetMatchID");
+  MarkNativeAsOptional("Get5_GetServerID");
   MarkNativeAsOptional("Get5_AddLiveCvar");
   MarkNativeAsOptional("Get5_IncreasePlayerStat");
   MarkNativeAsOptional("Get5_GetMatchStats");


### PR DESCRIPTION
The round backups cannot be completed as OnRoundStart events are not hooked in by default.

This is just to test some stuff on the lower version of get5 and bringing some compatibility backwards where it can be included. This will also allow loading of backups from a remote URL. This does not do any checks to see if there is a game currently live, as that should be done by the API. @kyoto44 if you would like, feel free to test these new end points out.

Thanks!