### PR TITLE
demo-upload: fix broken map number

### DIFF
--- a/scripting/G5WS.sp
+++ b/scripting/G5WS.sp
@@ -532,7 +532,7 @@ public void Get5_OnDemoFinished(const Get5DemoFinishedEvent event){
   if (g_EnableDemoUpload.BoolValue && filename[0]) {
     LogDebug("About to enter UploadDemo. SO YES WE ARE. Our match ID is %s", matchId);
     int mapNumber = event.MapNumber;
-    HTTPRequest req = CreateDemoRequest("match/%s/map/%d/demo", matchId, mapNumber-1);
+    HTTPRequest req = CreateDemoRequest("match/%s/map/%d/demo", matchId, mapNumber);
     JSONObject demoJSON = new JSONObject();
     LogDebug("Our api url: %s", g_storedAPIURL);
     // Send demo file name to store in database to show users at end of match.
@@ -541,7 +541,7 @@ public void Get5_OnDemoFinished(const Get5DemoFinishedEvent event){
       LogDebug("Our demo string: %s", filename);
       demoJSON.SetString("demoFile", filename);
       req.Post(demoJSON, RequestCallback);
-      req = CreateDemoRequest("match/%s/map/%d/demo/upload/%s", matchId, mapNumber-1, g_storedAPIKey);
+      req = CreateDemoRequest("match/%s/map/%d/demo/upload/%s", matchId, mapNumber, g_storedAPIKey);
       if (req != null) {
         LogDebug("Uploading demo to server...");
         req.UploadFile(filename, OnDemoUploaded);


### PR DESCRIPTION
Based on this, map 1 is getting mapNumber -1 and not 0. Then It breaks whole sequence of uploads.

```
0|G5API  | POST /match/16/map/-1/demo 404 1.530 ms - 46
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:07:05:56 +0000] "POST /match/16/map/-1/demo HTTP/1.1" 404 46 "-" "sm-ripext/1.3.1"
0|G5API  | PUT /match/16/map/-1/demo/upload/AXOKE36TDSTW9ZGZNEZ2QQYL 404 1.809 ms - 46
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:07:05:58 +0000] "PUT /match/16/map/-1/demo/upload/AXOKE36TDSTW9ZGZNEZ2QQYL HTTP/1.1" 404 46 "-" "sm-ripext/1.3.1"
0|G5API  | POST /match/15/map/-1/demo 404 1.053 ms - 46
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:07:07:44 +0000] "POST /match/15/map/-1/demo HTTP/1.1" 404 46 "-" "sm-ripext/1.3.1"
0|G5API  | PUT /match/15/map/-1/demo/upload/RG34W5F8JEJOYY5X9A850YM9 404 1.513 ms - 46
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:07:07:45 +0000] "PUT /match/15/map/-1/demo/upload/RG34W5F8JEJOYY5X9A850YM9 HTTP/1.1" 404 46 "-" "sm-ripext/1.3.1"
0|G5API  | POST /match/16/map/0/demo 200 14.709 ms - 21
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:07:57:28 +0000] "POST /match/16/map/0/demo HTTP/1.1" 200 21 "-" "sm-ripext/1.3.1"
0|G5API  | PUT /match/16/map/0/demo/upload/AXOKE36TDSTW9ZGZNEZ2QQYL 500 1.657 ms - 45
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:07:57:29 +0000] "PUT /match/16/map/0/demo/upload/AXOKE36TDSTW9ZGZNEZ2QQYL HTTP/1.1" 500 45 "-" "sm-ripext/1.3.1"
0|G5API  | GET /demo/16_map2_de_inferno.zip 200 1.078 ms - 129392914
0|G5API  | POST /match/15/map/0/demo 200 20.497 ms - 21
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:08:06:19 +0000] "POST /match/15/map/0/demo HTTP/1.1" 200 21 "-" "sm-ripext/1.3.1"
0|G5API  | PUT /match/15/map/0/demo/upload/RG34W5F8JEJOYY5X9A850YM9 500 1.706 ms - 45
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:08:06:20 +0000] "PUT /match/15/map/0/demo/upload/RG34W5F8JEJOYY5X9A850YM9 HTTP/1.1" 500 45 "-" "sm-ripext/1.3.1"
0|G5API  | GET /demo/16_map2_de_inferno.zip 200 0.935 ms - 129392914
0|G5API  | POST /match/15/map/1/demo 200 26.679 ms - 21
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:09:14:26 +0000] "POST /match/15/map/1/demo HTTP/1.1" 200 21 "-" "sm-ripext/1.3.1"
0|G5API  | PUT /match/15/map/1/demo/upload/RG34W5F8JEJOYY5X9A850YM9 500 1.563 ms - 45
0|G5API  | ::ffff:172.18.0.2 - - [24/Jul/2022:09:14:27 +0000] "PUT /match/15/map/1/demo/upload/RG34W5F8JEJOYY5X9A850YM9 HTTP/1.1" 500 45 "-" "sm-ripext/1.3.1"
```